### PR TITLE
make rgba in css color definition comply with standart

### DIFF
--- a/h2d/css/Parser.hx
+++ b/h2d/css/Parser.hx
@@ -523,9 +523,15 @@ class Parser {
 				if( v > 255 ) v = 255;
 				return v;
 			}
+			inline function check(k:Float) {
+				var v = Std.int(k);
+				if( v < 0 ) v = 0;
+				if( v > 255 ) v = 255;
+				return v;
+			}
 			if( r != null && g != null && b != null && a != null ) {
 				var a = conv(a); if( a == 0 ) a = 1; // prevent setting alpha to FF afterwards
-				(a << 24) | (conv(r) << 16) | (conv(g) << 8) | conv(b);
+				(a << 24) | (check(r) << 16) | (check(g) << 8) | check(b);
 			}
 			else
 				null;


### PR DESCRIPTION
Hi
Don't know if you accept this commit, but I was slightly confused when found that rgba definition is not following css standard. I did found it out only when tried to render semi-transparent colored div's.
This patch changes rgba definition from

```
rgba(1.0,1.0,1.0,0.3)
```

to

```
rgba(255,255,255,1.0)
```
