### PR TITLE
Ignore files/directories starting with . or _

### DIFF
--- a/hxd/res/FileTree.hx
+++ b/hxd/res/FileTree.hx
@@ -250,9 +250,9 @@ class FileTree {
 			var fileName = f;
 			var field = null;
 			var ext = null;
+			if( f.charCodeAt(0) == ".".code || f.charCodeAt(0) == "_".code )
+				continue;
 			if( sys.FileSystem.isDirectory(path) ) {
-				if( f.charCodeAt(0) == ".".code || f.charCodeAt(0) == "_".code )
-					continue;
 				field = handleDir(f, relPath.length == 0 ? f : relPath+"/"+f, path);
 			} else {
 				var extParts = f.split(".");


### PR DESCRIPTION
`FileTree.scanRec` currently only ignores directory names beginning with `'.'` or `'_'`. It should also ignore file names beginning with those characters. (It crashes when encountering file names beginning with `'.'`)