### PR TITLE
Update GlslOut.hx

### DIFF
--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -373,7 +373,7 @@ class GlslOut {
 		buf = new StringBuf();
 		exprValues = [];
 		//Version is required on desktop for precision qualifier, but version 1.0.0 only is supported on webgl
-		#if !js
+		#if (windows||linux)
 		decls.push("#version 130");
 		#end
 		decls.push("precision mediump float;");


### PR DESCRIPTION
Mobile using openglES were also concerned by this.

It would be certainly better to detect opengles in some way, rather than using such conditionals, but so far it works.