### PR TITLE
Fix alloc not occurring until render

### DIFF
--- a/h3d/scene/Mesh.hx
+++ b/h3d/scene/Mesh.hx
@@ -10,6 +10,7 @@ class Mesh extends Object {
 		this.primitive = prim;
 		if( mat == null ) mat = new h3d.mat.MeshMaterial(null);
 		this.material = mat;
+		this.primitive.alloc(null);
 	}
 
 	override function getBounds( ?b : h3d.col.Bounds, rec = false ) {


### PR DESCRIPTION
This fixes a bug where if the points in a `Polygon` primitive are edited before the first render but after a mesh is created with that primitive, then the mesh display the new points. Changing the points any time after that will not affect the object, so this behavior should be more logically consistent.