### PR TITLE
Timer improvements

### DIFF
--- a/hxd/Timer.hx
+++ b/hxd/Timer.hx
@@ -9,6 +9,9 @@ class Timer {
 	public static var calc_tmod : Float = 1;
 	public static var tmod : Float = 1;
 	public static var deltaT : Float = 1;
+
+	public static var smoothing : Bool = true;
+
 	static var frameCount = 0;
 
 	public inline static function update() {
@@ -17,9 +20,20 @@ class Timer {
 		deltaT = newTime - oldTime;
 		oldTime = newTime;
 		if( deltaT < maxDeltaTime )
-			calc_tmod = calc_tmod * tmod_factor + (1 - tmod_factor) * deltaT * wantedFPS;
+		{
+			if(smoothing)
+			{
+				calc_tmod = calc_tmod * tmod_factor + (1 - tmod_factor) * deltaT * wantedFPS;
+			}
+			else
+			{
+				calc_tmod = deltaT;
+			}
+		}
 		else
-			deltaT = 1 / wantedFPS;
+		{
+			calc_tmod = maxDeltaTime;
+		}
 		tmod = calc_tmod;
 	}
 

--- a/hxd/Timer.hx
+++ b/hxd/Timer.hx
@@ -29,7 +29,7 @@ class Timer {
 	}
 
 	public inline static function fps() : Float {
-		return wantedFPS/calc_tmod;
+		return 1/calc_tmod;
 	}
 
 	public static function skip() {

--- a/hxd/Timer.hx
+++ b/hxd/Timer.hx
@@ -10,8 +10,6 @@ class Timer {
 	public static var tmod : Float = 1;
 	public static var deltaT : Float = 1;
 
-	public static var smoothing : Bool = true;
-
 	static var frameCount = 0;
 
 	public inline static function update() {
@@ -21,14 +19,7 @@ class Timer {
 		oldTime = newTime;
 		if( deltaT < maxDeltaTime )
 		{
-			if(smoothing)
-			{
-				calc_tmod = calc_tmod * tmod_factor + (1 - tmod_factor) * deltaT * wantedFPS;
-			}
-			else
-			{
-				calc_tmod = deltaT;
-			}
+			calc_tmod = calc_tmod * tmod_factor + (1 - tmod_factor) * deltaT;
 		}
 		else
 		{


### PR DESCRIPTION
I noticed that the timer was making my timers inaccurate with respect to real time, so I added an option for turning the `deltaT` smoothing off.

I also fixed a bug where if `deltaT` was greater than `maxDeltaTime`, it would fall back to the previous frame's `calc_tmod`.