### PR TITLE
Fixed a bug in SpriteBatch bounds calculation

### DIFF
--- a/h2d/SpriteBatch.hx
+++ b/h2d/SpriteBatch.hx
@@ -174,7 +174,7 @@ class SpriteBatch extends Drawable {
 				y = py * ca + px * sa + e.y;
 				addBounds(relativeTo, out, x, y, 1e-10, 1e-10);
 			} else
-				addBounds(relativeTo, out, e.x + tile.dx, e.y + tile.dy, tile.width, tile.height);
+				addBounds(relativeTo, out, e.x + t.dx, e.y + t.dy, t.width, t.height);
 			e = e.next;
 		}
 	}


### PR DESCRIPTION
Bounds for a non scaled / rotated SpriteBatch only got calculated with the tile that is used to initialize the SpriteBatch.
Instead the tiles of the batch elements should be used to calculate the bounds. ;)

I do not like the fact that we have to pass a Tile to create a SpriteBatch. Instead we could pass the texture / atlas? It is a bit confusing when you first look at how it's done. Suggestions?