### PR TITLE
fix Anim not work when set frames in a later time.

### DIFF
--- a/h2d/Anim.hx
+++ b/h2d/Anim.hx
@@ -53,7 +53,9 @@ class Anim extends Drawable {
 		if( curFrame < frames.length )
 			return;
 		if( loop ) {
-			if(frames.length != 0)
+			if( frames.length == 0 )
+				curFrame = 0;
+			else
 				curFrame %= frames.length;
 			onAnimEnd();
 		} else if( curFrame >= frames.length ) {

--- a/h2d/Anim.hx
+++ b/h2d/Anim.hx
@@ -53,7 +53,8 @@ class Anim extends Drawable {
 		if( curFrame < frames.length )
 			return;
 		if( loop ) {
-			curFrame %= frames.length;
+			if(frames.length != 0)
+				curFrame %= frames.length;
 			onAnimEnd();
 		} else if( curFrame >= frames.length ) {
 			curFrame = frames.length;


### PR DESCRIPTION
create the Anim instance,then set the frames after atlas source loaded in a later time,the frames.length equals 0,"curFrame %= frames.length" make curFrame to NaN,so the anim stoped on the first  
 frame.