### PR TITLE
Pad rstick support

### DIFF
--- a/hxd/Pad.hx
+++ b/hxd/Pad.hx
@@ -615,7 +615,11 @@ class Pad {
 				if( i == 0 ) {
 					p.rawXAxis = x;
 					p.rawYAxis = y;
-					// TODO: support right axis
+				}
+				else if( i == 1 ) {
+					trace(i+" "+x+","+y);
+					p.rawRXAxis = x;
+					p.rawRYAxis = y;
 				}
 			}
 		}


### PR DESCRIPTION
This adds support for Right game pad axis in the same way as Left axis (throught `rxAxis` and `ryAxis` values).
Works for DX, SDL and JS.