### PR TITLE
Fix snd channel ended on 1st update if played with low volume or muted

### DIFF
--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -242,6 +242,8 @@ class Manager {
 		c.next         = channels;
 		c.isLoading    = sdat.isLoading();
 		c.isVirtual    = driver == null;
+		c.position     = 0;
+		c.positionChanged = false;
 
 		channels = c;
 		return c;

--- a/hxd/snd/Manager.hx
+++ b/hxd/snd/Manager.hx
@@ -242,8 +242,7 @@ class Manager {
 		c.next         = channels;
 		c.isLoading    = sdat.isLoading();
 		c.isVirtual    = driver == null;
-		c.position     = 0;
-		c.positionChanged = false;
+		c.lastStamp    = haxe.Timer.stamp();
 
 		channels = c;
 		return c;


### PR DESCRIPTION
The channel `lastStamp` is at 0 instead of being initialized at `haxe.Timer.stamp()` when `updateVirtualChannels` is called. Therefore, the position goes straight to the end.