### PR TITLE
Fix a bug with a render zone inside a render zone.

### DIFF
--- a/h2d/RenderContext.hx
+++ b/h2d/RenderContext.hx
@@ -498,10 +498,11 @@ class RenderContext extends h3d.impl.RenderContext {
 			return;
 		}
 
-		x = Math.max( x, renderX );
-		y = Math.max( y, renderY );
 		var x2 = Math.min( x + w, renderX + renderW );
 		var y2 = Math.min( y + h, renderY + renderH );
+		x = Math.max( x, renderX );
+		y = Math.max( y, renderY );
+
 		if (x2 < x) x2 = x;
 		if (y2 < y) y2 = y;
 


### PR DESCRIPTION
Having a render zone in a render zone can lead to an issue if the child zone is partly outside the parent zone : #1137 
To fix it, I changed the computation of the start position of the render zone after computing the end position.