### PR TITLE
Allow to set sample/bitrate when converting wav to mp3/ogg

### DIFF
--- a/hxd/fs/Convert.hx
+++ b/hxd/fs/Convert.hx
@@ -249,21 +249,19 @@ class ConvertWAV2MP3 extends Convert {
 	}
 
 	override function convert() {
-        var args = ["--silent"];
-        var sampleRate = 44100;
-        var bitRate = 128;
-        if(params != null) {
-          if(hasParam("samplerate")) {
-            sampleRate = getParam("samplerate");
-          }
-          if(hasParam("bitrate")) {
-            bitRate = getParam("bitrate");
-          }
-        }
-        args = args.concat(["--resample", Std.string(sampleRate)]);
-        args = args.concat(["-b", Std.string(bitRate)]);
-        args = args.concat([srcPath, dstPath]);
-        command("lame", args);
+		var args = ["--silent"];
+		var sampleRate = 44100;
+		if(hasParam("samplerate")) {
+			sampleRate = getParam("samplerate");
+		}
+		if(hasParam("bitrate")) {
+			args = args.concat(["-b", Std.string(getParam("bitrate"))]);
+		} else {
+			args.push("-h");
+		}
+		args = args.concat(["--resample", Std.string(sampleRate)]);
+		args = args.concat([srcPath, dstPath]);
+		command("lame", args);
 	}
 
 	static var _ = Convert.register(new ConvertWAV2MP3());
@@ -278,27 +276,24 @@ class ConvertWAV2OGG extends Convert {
 		var cmd = "oggenc";
 		if (Sys.systemName() == "Windows")
 			cmd = "oggenc2";
-        var args = ["--quiet"];
-        var sampleRate = 44100;
-        var bitRate = 128;
-        if(hasParam("samplerate")) {
-          sampleRate = getParam("samplerate");
-        }
-        if(hasParam("bitrate")) {
-          bitRate = getParam("bitrate");
-        }
+		var args = ["--quiet"];
+		var sampleRate = 44100;
+		if(hasParam("samplerate")) {
+			sampleRate = getParam("samplerate");
+		}
 		if (hasParam("mono")) {
 			var f = sys.io.File.read(srcPath);
 			var wav = new format.wav.Reader(f).read();
 			f.close();
 			if (wav.header.channels >= 2) {
 				args.push("--downmix");
-                if(bitRate > 160) bitRate = 160;
-            }
+			}
 		}
-        args = args.concat(["--resample", Std.string(sampleRate)]);
-        args = args.concat(["-b", Std.string(bitRate)]);
-        args = args.concat([srcPath, "-o", dstPath]);
+		if(hasParam("bitrate")) {
+			args = args.concat(["-b", Std.string(getParam("bitrate"))]);
+		}
+		args = args.concat(["--resample", Std.string(sampleRate)]);
+		args = args.concat([srcPath, "-o", dstPath]);
 		command(cmd, args);
 	}
 


### PR DESCRIPTION
Although resampling to 44100hz by default might be debatable, it remains the default behavior for backward compatibility.