### PR TITLE
[CI] runs also with latest haxe, add build all.hxml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,25 +6,35 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-samples:
+  build:
+    strategy:
+      matrix:
+        haxe-version: [latest, 4.3.7]
+      fail-fast: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: krdlab/setup-haxe@v1
       with:
-        haxe-version: 4.3.6
+        haxe-version: ${{ matrix.haxe-version }}
     - name: Print Haxe version
       run: |
         haxe --version
     - name: Install haxelib deps
       run: |
+        haxelib dev heaps .
         haxelib git format https://github.com/HaxeFoundation/format
         haxelib git hxbit https://github.com/ncannasse/hxbit
         haxelib git hscript https://github.com/HaxeFoundation/hscript
         haxelib git domkit https://github.com/HeapsIO/domkit
         haxelib git hide https://github.com/HeapsIO/hide
         haxelib git hlsdl https://github.com/HaxeFoundation/hashlink master libs/sdl
-        haxelib dev heaps .
+        haxelib git castle https://github.com/ncannasse/castle
+        haxelib git hldx https://github.com/HaxeFoundation/hashlink master libs/directx
+        haxelib git hlopenal https://github.com/HaxeFoundation/hashlink master libs/openal
+    - name: Build all.hxml
+      run: |
+        haxe all.hxml
     - name: Build samples
       run: |
         cd samples


### PR DESCRIPTION
So we might detect simple compilation error such as in https://github.com/HeapsIO/heaps/commit/4bfe0601025cd5529e960de8062dd8a06a847224 (for https://github.com/HeapsIO/heaps/commit/b30a8b436320563c7e4f1ce48cb338f8535183fa)

all.hxml was run in .travis before https://github.com/HeapsIO/heaps/blob/2.1.1/.travis.yml