### PR TITLE
RenderDoc: add in application support on hl

### DIFF
--- a/hxd/tools/RenderDoc.hx
+++ b/hxd/tools/RenderDoc.hx
@@ -1,6 +1,6 @@
 package hxd.tools;
 
-#if (hl && hl_ver >= version("1.16.0"))
+#if hl
 enum abstract RenderDocInputButton(Int) {
 	// '0' - '9' matches ASCII values
 	var Key_0 = 0x30;


### PR DESCRIPTION
Related
- https://github.com/HaxeFoundation/hashlink/pull/820

Usage:

- Install:
  - Install RenderDoc from https://renderdoc.org/
  - Copy the shared library to your PATH (e.g. `renderdoc.dll`)
- In game code:
```haxe
// Init should be called before any call on graphic engine, for example in static function main()
// Put a -D here so we can enable/disable it in hxml
#if renderdoc
	if( !hxd.tools.RenderDoc.init() )
		throw "Can't init RenderDoc, renderdoc.dll may be missing from your PATH!";
	hxd.tools.RenderDoc.launchReplayUi(true, null); // Launch Installed RenderDoc UI
	hxd.tools.RenderDoc.setCaptureKeys([Key_F11]); // F12 is used by VSCode for breakpoint so use another key here
#end
```
- To trigger a capture of next frame from code
```haxe
#if renderdoc
	hxd.tools.RenderDoc.triggerCapture();
#end
```
- To trigger a custom capture from code (default device and window)
```haxe
#if renderdoc
	hxd.tools.RenderDoc.startFrameCapture(null, null);
	// do rendering stuff
	hxd.tools.RenderDoc.endFrameCapture(null, null);
#end
```