### PR TITLE
Fix stencil clone and load issue

### DIFF
--- a/h3d/mat/Stencil.hx
+++ b/h3d/mat/Stencil.hx
@@ -57,12 +57,34 @@ class Stencil {
 		var s = new Stencil();
 		s.opBits = opBits;
 		s.maskBits = maskBits;
+		s.readMask = readMask;
+		s.writeMask = writeMask;
+		s.reference = reference;
+		s.frontTest = frontTest;
+		s.frontPass = frontPass;
+		s.frontSTfail = frontSTfail;
+		s.frontDPfail = frontDPfail;
+		s.backTest = backTest;
+		s.backPass = backPass;
+		s.backSTfail = backSTfail;
+		s.backDPfail = backDPfail;
 		return s;
 	}
 
 	public function load(s : Stencil) {
 		opBits = s.opBits;
 		maskBits = s.maskBits;
+		readMask = s.readMask;
+		writeMask = s.writeMask;
+		reference = s.reference;
+		frontTest = s.frontTest;
+		frontPass = s.frontPass;
+		frontSTfail = s.frontSTfail;
+		frontDPfail = s.frontDPfail;
+		backTest = s.backTest;
+		backPass = s.backPass;
+		backSTfail = s.backSTfail;
+		backDPfail = s.backDPfail;
 	}
 
 }


### PR DESCRIPTION
The stencil clone and load are not working properly. I does not copy some variables, which are causing issues.
Like if I do this, it will trace "clone is incorrect" and "load is incorrect"
```
final s1 = new Stencil();
final ref1 = 1;
final read1 = 2;
final write1 = 3;
s1.setFunc(h3d.mat.Data.Compare.Always, ref1, read1, write1);
s1.setOp(h3d.mat.Data.StencilOp.Keep, h3d.mat.Data.StencilOp.Keep, h3d.mat.Data.StencilOp.Keep);

final s2 = s1.clone();

final s3 = new Stencil();
s3.load(s1);

if (s1.readMask != s2.readMask) {
	trace("clone is incorrect. s1.readMask: ", s1.readMask, " s2.readMask: ", s2.readMask);
}

if (s1.readMask != s2.readMask) {
	trace("load is incorrect. s1.readMask: ", s1.readMask, " s3.readMask: ", s3.readMask);
}
```

output:
```
clone is incorrect. s1.readMask: , 2,  s2.readMask: , 255
load is incorrect. s1.readMask: , 2,  s3.readMask: , 255
```

This commit makes sure that all members are copied, similar to how Pass.hx does it.