### PR TITLE
fix camera load

### DIFF
--- a/h3d/Camera.hx
+++ b/h3d/Camera.hx
@@ -503,6 +503,8 @@ class Camera {
 			follow = null;
 		viewX = cam.viewX;
 		viewY = cam.viewY;
+		rightHanded = cam.rightHanded;
+		reverseDepth = cam.reverseDepth;
 		update();
 	}
 


### PR DESCRIPTION
In my game I'm using `rightHanded = true`. This has worked fine until i decided to download the latest Heaps version, because in commit 9df4f9d3d3bb975f3862aa976c6b690b142b23d2 he changed `camera = cam;` to `camera.load(cam);`. The load does not copy all member variables, so this commit made my game visually broken. I now added `rightHanded = cam.rightHanded;` and I also added `reverseDepth = cam.reverseDepth;`, beacuse that variable was also not getting copied.