### PR TITLE
[hmd] Store lodConfig in model.props instead of props.json

### DIFF
--- a/h3d/prim/ModelDatabase.hx
+++ b/h3d/prim/ModelDatabase.hx
@@ -19,7 +19,6 @@ class ModelDatabase {
 	static var FILE_NAME = "model.props";
 
 	static var LOD_CONFIG = "lodConfig";
-	static var LOD_CONFIG_FIELD = "lods.screenRatio";
 	static var DYN_BONES_CONFIG = "dynamicBones";
 
 	public static dynamic function customizeLodConfig(c : Array<Float>) {


### PR DESCRIPTION
Because props.json is not baked with the games, we move the config in model.props, in the "default" key. We rename lods.screenRatio to just lodConfig to be consistent with how the data is already stored in model.props