### PR TITLE
Fixing clone issue of JointsData

### DIFF
--- a/h3d/scene/Skin.hx
+++ b/h3d/scene/Skin.hx
@@ -339,10 +339,6 @@ class Skin extends MultiMaterial {
 		var s = o == null ? new Skin(null,materials.copy()) : cast o;
 		super.clone(s);
 		s.setSkinData(skinData);
-
-		s.jointsData = [];
-		s.makeJointsData();
-
 		return s;
 	}
 
@@ -616,4 +612,3 @@ class Skin extends MultiMaterial {
 	}
 
 }
-


### PR DESCRIPTION
Cloning JointsData object using Reflect.copy here will result in an anonymous objects and subsequently result in a crash when Skin is attempting to call sync() function on joints.