### PR TITLE
add anti aliasing option

### DIFF
--- a/h2d/RenderContext.hx
+++ b/h2d/RenderContext.hx
@@ -151,6 +151,9 @@ class RenderContext extends h3d.impl.RenderContext {
 		cameraStackIndex = 0;
 		filterStack = [];
 		filterStackIndex = 0;
+		#if anti_aliasing
+		globals.set("global.antiAliasing", 0);
+		#end
 	}
 
 	override function dispose() {

--- a/h3d/scene/RenderContext.hx
+++ b/h3d/scene/RenderContext.hx
@@ -46,6 +46,9 @@ class RenderContext extends h3d.impl.RenderContext {
 	@global("global.modelViewInverse") var globalModelViewInverse : h3d.Matrix;
 	@global("global.previousModelView") var globalPreviousModelView : h3d.Matrix;
 	@global("global.frame") var globalFrame : Int;
+	#if anti_aliasing
+	@global("global.antiAliasing") var globalAntiAliasing : Int;
+	#end
 
 	var allocPool : h3d.pass.PassObject;
 	var allocFirst : h3d.pass.PassObject;
@@ -67,6 +70,9 @@ class RenderContext extends h3d.impl.RenderContext {
 		cachedShaderList = [];
 		cachedPassObjects = [];
 		initGlobals();
+		#if anti_aliasing
+		globalAntiAliasing = 0;
+		#end
 	}
 
 	public function setCamera( cam : h3d.Camera ) {

--- a/h3d/shader/Texture.hx
+++ b/h3d/shader/Texture.hx
@@ -6,6 +6,12 @@ class Texture extends hxsl.Shader {
 		@input var input : {
 			var uv : Vec2;
 		};
+		
+		#if anti_aliasing
+		@global var global: { 
+            var antiAliasing: Int; 
+        };
+		#end
 
 		@const var additive : Bool;
 		@const var killAlpha : Bool;
@@ -22,7 +28,21 @@ class Texture extends hxsl.Shader {
 		}
 
 		function fragment() {
+			#if anti_aliasing
+			var c = if (global.antiAliasing == 1) {
+				var dx = dFdx(input.uv);
+				var dy = dFdy(input.uv);
+				var c0 = texture.get(input.uv + 0.25 * dx + 0.25 * dy);
+				var c1 = texture.get(input.uv + 0.25 * dx - 0.25 * dy);
+				var c2 = texture.get(input.uv - 0.25 * dx + 0.25 * dy);
+				var c3 = texture.get(input.uv - 0.25 * dx - 0.25 * dy);
+				(c0 + c1 + c2 + c3) * 0.25;
+			} else {
+				texture.get(calculatedUV);
+			}
+			#else
 			var c = texture.get(calculatedUV);
+			#end
 			if( killAlpha && c.a - killAlphaThreshold < 0 ) discard;
 			if( additive )
 				pixelColor += c;


### PR DESCRIPTION
Normally to reduce aliasing in games mip maps are used, but mip maps increases the amount of texture memory used with around 50%. Another way to get the same effect as mip maps is to sample the texture 4 times and take an average of the color value. This solution works good on web devices where we would like to minimize the used memory. To the users who want this type of anti aliasing they can set the compile flag `-D anti_aliasing` in their `build.hxml` and also set the runtime flag `globals.set("global.antiAliasing", 1);`.