### PR TITLE
Fix .png load crash

### DIFF
--- a/hxd/res/Image.hx
+++ b/hxd/res/Image.hx
@@ -127,6 +127,9 @@ class Image extends Resource {
 						var colbits = f.readByte();
 						var colType = f.readByte();
 						inf.pixelFormat = switch ([colbits, colType]) {
+							case [1, _]: BGRA;
+							case [2, _]: BGRA;
+							case [4, _]: BGRA;
 							case [8, _]: BGRA; // TODO : grayscale png image
 							case [16, 0]: R16U;
 							case [16, 2]: RGBA16U; // RGB16U is not supported on DirectX !


### PR DESCRIPTION
Before if a .png image had colbits 1,2 or 4 it would crash the program. I added some extra case which loads the images successfully. I have attached one image called "green_pink4" that has colbits 1 and image "green_pink162" that has colbits 2, that you can verify that this works. I have tested with an image with colbits 4 also, but that is a private image so I can not share that one.

<img width="40" height="40" alt="green_pink4" src="https://github.com/user-attachments/assets/ec134d81-91fb-4934-8e78-72f3df0c5e75" />
<img width="160" height="160" alt="green_pink162" src="https://github.com/user-attachments/assets/e6891be9-8899-489a-89fa-8e8eeff3c7b1" />

