### PR TITLE
[Flow] Fix line height of first line in multiline flow

### DIFF
--- a/h2d/Flow.hx
+++ b/h2d/Flow.hx
@@ -1426,6 +1426,7 @@ class Flow extends Object {
 			});
 
 			// position all not absolute nodes
+			maxLineHeight = 0;
 			forChildren(function(i, p, c) {
 				if( p.autoSizeWidth != null || p.autoSizeHeight != null )
 					calcSize(p, c);

--- a/h2d/Flow.hx
+++ b/h2d/Flow.hx
@@ -1625,6 +1625,7 @@ class Flow extends Object {
 			});
 
 			// position all not absolute nodes
+			maxColWidth = 0;
 			forChildren(function(i, p, c) {
 				if( p.autoSizeWidth != null || p.autoSizeHeight != null )
 					calcSize(p, c);


### PR DESCRIPTION
The issue can be easily reproduced with this sample:
```haxe
import h2d.Tile;
import h2d.Bitmap;
import h2d.Flow;

class Main extends hxd.App {
	static public function main() {
		new Main();
	}

	override function init() {
		var flow = new Flow(s2d);
		flow.maxWidth = 200;
		flow.multiline = true;
		flow.debug = true;

		new Bitmap(Tile.fromColor(0xFF00FF, 200, 10), flow);
		new Bitmap(Tile.fromColor(0x00FFFF, 20, 40), flow);
		new Bitmap(Tile.fromColor(0xFFFF00, 10, 20), flow);

		var flow = new Flow(s2d);
		flow.maxWidth = 200;
		flow.multiline = true;
		flow.verticalAlign = Top;
		flow.x = 250;
		flow.debug = true;

		new Bitmap(Tile.fromColor(0x00FFFF, 200, 10), flow);
		new Bitmap(Tile.fromColor(0x00FFFF, 20, 40), flow);
		new Bitmap(Tile.fromColor(0xFFFF00, 10, 20), flow);
	}
}
```

Resetting `maxLineHeight` to `0` before positioning nodes makes sure previously calculated `maxLineHeight` isn't being used for first line when it should not.

Current heaps:
<img width="450" height="80" alt="2025-11-24-17:06-39-969032179" src="https://github.com/user-attachments/assets/2d79b30e-0dfc-434f-baab-edc11c5ad8bb" />

With this patch:
<img width="450" height="80" alt="2025-11-24-17:06-54-352489809" src="https://github.com/user-attachments/assets/a48015e2-0dbe-4520-b9c3-5a46d270ba44" />

_Tested with shiroTools `73faca1146`_