### PR TITLE
[hxsl] Fix heaps_compact_mem on GlslOut, Linker

### DIFF
--- a/hxsl/Ast.hx
+++ b/hxsl/Ast.hx
@@ -195,6 +195,24 @@ class TVar {
 	var kind : VarKind;
 	@:optional var parent : TVar;
 	@:optional var qualifiers : Null<Array<VarQualifier>>;
+
+	#if heaps_compact_mem
+	/**
+		Clone but keep the same id, useful when v is inside a read-only memory.
+	**/
+	public function clone() : TVar {
+		var v = this;
+		var v2 : TVar = {
+			id : v.id,
+			name : v.name,
+			type : v.type,
+			kind : v.kind,
+			parent : v.parent?.clone(),
+			qualifiers : v.qualifiers?.copy(),
+		}
+		return v2;
+	}
+	#end
 }
 
 typedef TFunction = {

--- a/hxsl/GlslOut.hx
+++ b/hxsl/GlslOut.hx
@@ -215,6 +215,9 @@ class GlslOut {
 	function addVar( v : TVar ) {
 		switch( v.type ) {
 		case TArray(t, size):
+			#if heaps_compact_mem
+			var v = v.clone();
+			#end
 			var old = v.type;
 			v.type = t;
 			addVar(v);
@@ -237,6 +240,9 @@ class GlslOut {
 			}
 			add((isVertex ? "vertex_" : "") + "uniform_buffer"+(uniformBuffer++));
 			add(" { ");
+			#if heaps_compact_mem
+			var v = v.clone();
+			#end
 			v.type = TArray(t,size);
 			addVar(v);
 			v.type = TBuffer(t,size,kind);

--- a/hxsl/Linker.hx
+++ b/hxsl/Linker.hx
@@ -440,6 +440,10 @@ class Linker {
 					if ( v.kind == Local ) {
 						if ( v2.v.qualifiers == null )
 							v2.v.qualifiers = [];
+						#if heaps_compact_mem
+						else
+							v2.v.qualifiers = v2.v.qualifiers.copy();
+						#end
 						var qualifier = isBatchParam ? Flat : NoVar;
 						if ( !v2.v.hasQualifier(qualifier) )
 							v2.v.qualifiers.push(qualifier);


### PR DESCRIPTION
Compacted memory (shader data) are read only.
Setting compact flag to 1 allow us to see the read access violation.