### PR TITLE
add support for intel's new Intel GPU naming schema when checking for if intelDriverFix is needed

### DIFF
--- a/h3d/impl/GlDriver.hx
+++ b/h3d/impl/GlDriver.hx
@@ -174,7 +174,7 @@ class GlDriver extends Driver {
 		hasMultiIndirect = gl.getConfigParameter(0) > 0;
 		maxCompressedTexturesSupport = 7;
 		var driver = getDriverName(false).toLowerCase();
-		isIntelGpu = ~/intel.*graphics/.match(driver);
+		isIntelGpu = ~/intel.*(graphics|gpu)/.match(driver);
 		#end
 
 		#if (hlsdl >= version("1.15.0"))


### PR DESCRIPTION
some newer Intel GPU's (for instance `Intel(R) Arc(TM) 140V GPU (16GB)` omit the word `Graphics` in favor of `GPU` in their `GL_RENDERER` string
these new chips (at least with the current driver) still require the `intelDriverFix` to be present, and making the regex recognize this new schema fixes the issue