### PR TITLE
Support loading json font atlas as generated by msdf-atlas-gen + fix font kerning offset to Float

### DIFF
--- a/h2d/Font.hx
+++ b/h2d/Font.hx
@@ -63,7 +63,7 @@ class FontChar {
 	/**
 		Adds a new kerning to the character with specified `prevChar` and `offset`.
 	**/
-	public function addKerning( prevChar : Int, offset : Int ) {
+	public function addKerning( prevChar : Int, offset : Float ) {
 		var k = new Kerning(prevChar, offset);
 		k.next = kerning;
 		kerning = k;


### PR DESCRIPTION
Supports loading the output of `Chlumsky/msdf-atlas-gen` directly. This has the following benefits:
- existing forks of https://github.com/Yanrishatum/fontgen bitrot to the edge of compilability
- they only output to the BMFont format, which only has Int parameters for bounds/offsets, which is a real precision killer
- using their upstream tool directly (https://github.com/Chlumsky/msdf-atlas-gen) is much more straightforward, and retains precision

Example atlas generation (msdf):

```
/bin/msdf-atlas-gen -font a-font.ttf  -format png -pots -size 32 -json atlas.fnt -imageout atlas.png -yorigin top
```
Load it with channels=4, or specify `-type sdf` and use say channel 0.

Note: you might want to up the `-size`, depending on the font. Size=64 produced better spacings than size=32 for a random test font (arial-like, as is the sdf_font of the Text.hs example).

*Edit*: also, small change to take Float for glyph kerning. It was already stored as Float, but took Int (which sufficed so far). But with getting raw Float data now, it makes a real difference.