### PR TITLE
[hmd] Keep empty root if root only child is used in an animation

### DIFF
--- a/hxd/fmt/fbx/HMDOut.hx
+++ b/hxd/fmt/fbx/HMDOut.hx
@@ -1139,9 +1139,27 @@ class HMDOut extends BaseLibrary {
 			return;
 
 		objects = [];
-		if( root.childs.length <= 1 && root.model == null ) {
-			root = root.childs[0];
-			root.parent = null;
+		if( root.childs.length <= 1 && root.model == null) {
+			var newRoot = root.childs[0];
+			var newRootHasAnim = false;
+			if (newRoot.model != null) {
+				var rootName = newRoot.model.getName();
+				for (anim in d.animations) {
+					for (obj in anim.objects) {
+						if (obj.name == rootName) {
+							newRootHasAnim = true;
+							break;
+						}
+					}
+					if (newRootHasAnim)
+						break;
+				}
+			}
+
+			if (!newRootHasAnim) {
+				root = root.childs[0];
+				root.parent = null;
+			}
 		}
 		if( root != null ) indexRec(root); // reorder after we have changed hierarchy
 
@@ -1721,14 +1739,14 @@ class HMDOut extends BaseLibrary {
 
 		dataOut = new haxe.io.BytesOutput();
 
-		addModels(includeGeometry);
-
 		var names = getAnimationNames();
 		for ( animName in names ) {
 			var anim = loadAnimation(animName);
 			if(anim != null)
 				d.animations.push(makeAnimation(anim));
 		}
+
+		addModels(includeGeometry);
 
 		d.data = dataOut.getBytes();
 		return d;


### PR DESCRIPTION
This ensures that renaming the root h3d.Object don't break animations