### PR TITLE
Fix point shadow bias

### DIFF
--- a/h3d/pass/PointShadowMap.hx
+++ b/h3d/pass/PointShadowMap.hx
@@ -28,7 +28,7 @@ class PointShadowMap extends CubeShadowMap {
 			throw "assert";
 		var pointLight = cast(light, h3d.scene.pbr.PointLight);
 		pshader.shadowMap = texture;
-		pshader.shadowBias = bias;
+		pshader.shadowBias = bias * pointLight.range;
 		pshader.shadowPower = power;
 		pshader.lightPos = light.getAbsPos().getPosition();
 		pshader.zFar = pointLight.range;


### PR DESCRIPTION
Scale the point shadow bias by the light's range to avoid self-shadowing (shadow acne/grain)

<img width="486" height="411" alt="Screenshot 2026-03-02 at 00 14 20" src="https://github.com/user-attachments/assets/070ad808-4f02-4a78-a34f-2b6de05993be" />
