### PR TITLE
[events] Capture mouse at the OS level in sceneEvent startCapture

### DIFF
--- a/hxd/SceneEvents.hx
+++ b/hxd/SceneEvents.hx
@@ -386,12 +386,14 @@ class SceneEvents {
 		if ( currentDrag != null && currentDrag.onCancel != null )
 			currentDrag.onCancel();
 		currentDrag = { f: f, ref: touchId, onCancel: onCancel };
+		window.captureMouseEvents(true);
 	}
 
 	public function stopCapture() {
 		if ( currentDrag != null && currentDrag.onCancel != null )
 			currentDrag.onCancel();
 		currentDrag = null;
+		window.captureMouseEvents(false);
 	}
 
 	@:deprecated("Renamed to startCapture") @:dox(hide)

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -243,7 +243,7 @@ class Window {
 	}
 
 	public function captureMouseEvents(enable: Bool) : Void {
-		#if (hldx || hlsdl)
+		#if (hldx >= version("1.16.0") || hlsdl >= version("1.16.0"))
 		window.captureMouseEvents(enable);
 		#end
 	}

--- a/hxd/Window.hl.hx
+++ b/hxd/Window.hl.hx
@@ -242,6 +242,12 @@ class Window {
 		if (emitEvent) event(new hxd.Event(EMove, x, y));
 	}
 
+	public function captureMouseEvents(enable: Bool) : Void {
+		#if (hldx || hlsdl)
+		window.captureMouseEvents(enable);
+		#end
+	}
+
 	@:deprecated("Use the displayMode property instead")
 	public function setFullScreen( v : Bool ) : Void {
 		#if (hldx || hlsdl)

--- a/hxd/Window.hx
+++ b/hxd/Window.hx
@@ -114,7 +114,7 @@ class Window {
 	public function setCursorPos( x : Int, y : Int, emitEvent : Bool = false ) : Void {
 		throw "Not implemented";
 	}
-	
+
 	public function setCurrent() {
 	}
 
@@ -183,5 +183,8 @@ class Window {
 	}
 	function set_title( t : String ) : String {
 		return t;
+	}
+
+	public function captureMouseEvents(enable: Bool) : Void {
 	}
 }

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -300,6 +300,12 @@ class Window {
 		if (emitEvent) event(new hxd.Event(EMove, x, y));
 	}
 
+	public function captureMouseEvents(enable: Bool) : Void {
+		// capturing mouse event is currently not supported on js target
+		// because it must be made in response to a mouse event
+		// see : https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
+	}
+
 	public function setCurrent() {
 		inst = this;
 	}

--- a/hxd/Window.js.hx
+++ b/hxd/Window.js.hx
@@ -69,6 +69,8 @@ class Window {
 	var focused : Bool;
 	var observer : Dynamic;
 
+	var lastPointerId : Int;
+
 	/**
 		When enabled, the browser zoom does not affect the canvas.
 		(default : true)
@@ -139,6 +141,8 @@ class Window {
 		element.addEventListener("keypress", onKeyPress);
 		element.addEventListener("blur", onFocus.bind(false));
 		element.addEventListener("focus", onFocus.bind(true));
+		element.addEventListener("pointerdown", onPointerDown);
+		element.addEventListener("pointerup", onPointerUp);
 
 		if ((js.Browser.window:Dynamic).ResizeObserver != null) {
 			// Modern solution for canvas resize monitoring, supported in most browsers, but not Haxe API.
@@ -301,9 +305,17 @@ class Window {
 	}
 
 	public function captureMouseEvents(enable: Bool) : Void {
-		// capturing mouse event is currently not supported on js target
-		// because it must be made in response to a mouse event
-		// see : https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture
+		if (lastPointerId < 0)
+			return;
+		if (enable) {
+			try {
+				canvas.setPointerCapture(lastPointerId);
+			} catch(e) {};
+		} else {
+			try {
+				canvas.releasePointerCapture(lastPointerId);
+			} catch(e) {};
+		}
 	}
 
 	public function setCurrent() {
@@ -547,6 +559,14 @@ class Window {
 	function onFocus(b: Bool) {
 		event(new Event(b ? EFocus : EFocusLost));
 		focused = b;
+	}
+
+	function onPointerDown(e:js.html.PointerEvent) {
+		lastPointerId = e.pointerId;
+	}
+
+	function onPointerUp(e:js.html.PointerEvent) {
+		lastPointerId = -1;
 	}
 
 	function get_isFocused() : Bool return focused;


### PR DESCRIPTION
This allows the mouse position and events can be correctly tracked even when the mouse moves outside the window.

Depends on https://github.com/HaxeFoundation/hashlink/pull/921